### PR TITLE
chore: update OneTrust settings

### DIFF
--- a/src/components/layout/cookie-consent/index.tsx
+++ b/src/components/layout/cookie-consent/index.tsx
@@ -1,30 +1,33 @@
 "use client";
-import React, { useEffect } from "react";
-import * as CookieConsent from "vanilla-cookieconsent";
-import pluginConfig from "./cookie-consent-config";
+import React from "react";
 import { Button } from "components/ui/button";
 
 declare global {
   interface Window {
-    CookieConsent: typeof CookieConsent;
+    Optanon: any;
+    OnetrustActiveGroups: string;
   }
 }
 
 const CookieConsentComponent = () => {
-  useEffect(() => {
-    if (window) {
-      CookieConsent.run(pluginConfig);
+  function displayConsentManager() {
+    if (
+      window &&
+      typeof window.Optanon !== "undefined" &&
+      typeof window.Optanon.ToggleInfoDisplay === "function"
+    ) {
+      window.Optanon.ToggleInfoDisplay();
     } else {
       console.log("CookieConsent not found");
     }
-  }, []);
+  }
 
   return (
     <div>
       <Button
         variant={"link"}
-        aria-label={"Privacy Policy"}
-        onClick={CookieConsent.showPreferences}
+        aria-label={"Cookies"}
+        onClick={displayConsentManager}
         className="px-0 text-sm font-thin  text-gray-200 sm:text-center"
       >
         Cookies

--- a/src/components/reusables/analytics.tsx
+++ b/src/components/reusables/analytics.tsx
@@ -3,17 +3,15 @@
 import { useEffect } from "react";
 import { usePathname } from "next/navigation";
 import { analytics } from "lib/segment";
-import * as CookieConsent from "vanilla-cookieconsent";
 
 export default function Analytics() {
   const pathname = usePathname();
-  const cookie = typeof document !== "undefined" ? CookieConsent.getCookie() : null;
 
   useEffect(() => {
-    if (cookie && cookie.categories?.includes("analytics")) {
+    if (window && window.OnetrustActiveGroups?.includes("2")) {
       analytics.page();
     }
-  }, [pathname, cookie]);
+  }, [pathname]);
 
   return null;
 }

--- a/src/components/reusables/link-trackers.tsx
+++ b/src/components/reusables/link-trackers.tsx
@@ -3,7 +3,6 @@ import React, { AnchorHTMLAttributes } from "react";
 import Link, { LinkProps } from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
 import { analytics } from "lib/segment";
-import * as CookieConsent from "vanilla-cookieconsent";
 
 interface LinkTrackersProps extends LinkProps {
   target?: AnchorHTMLAttributes<HTMLAnchorElement>["target"];
@@ -24,7 +23,6 @@ export const LinkTrackers: React.FC<LinkTrackersProps> = ({
 }) => {
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const cookie = typeof document !== "undefined" ? CookieConsent.getCookie() : null;
 
   const handleOnClick = (
     e: React.MouseEvent<HTMLAnchorElement, MouseEvent>
@@ -38,7 +36,7 @@ export const LinkTrackers: React.FC<LinkTrackersProps> = ({
 
     if (target === "_blank") e.preventDefault();
 
-    if (cookie?.categories?.includes("analytics")) {
+    if (window && window.OnetrustActiveGroups?.includes("2")) {
       analytics.track(segmentMsg, {
         ...segmentOpt,
         url: fullPath,


### PR DESCRIPTION
# Description

OneTrust banner enabled on the site. Removing the open source cookie consent manager and use OneTrust settings instead. 

## Type of Change

- [ ] Bugfix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
