### PR TITLE
fix: delete cache error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,18 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Delete cache job
+  delete-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Delete all caches
+        run: gh cache delete --all
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
   # Build job
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -33,6 +33,8 @@ jobs:
   delete-cache:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Delete all caches
         run: gh cache delete --all
         env:


### PR DESCRIPTION
# Description

Fix git repository error in delete cache step and add cache deletion to PR builds (https://github.com/agntcy/agntcy-website/actions/runs/19571874658/job/56047119159)

This PR addresses the fatal: not a git repository error occurring during the delete cache step by ensuring the repository is properly checked out before running git commands.

### Changes:

Fixed error: failed to determine base repo: failed to run git: fatal: not a git repository (or any of the parent directories): .git
Added delete cache step to PR build job for consistency
Ensured proper repository checkout before cache operations

## Type of Change

- [X] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
