### PR TITLE
fix: remove deprecated TypeScript baseUrl

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,34 +22,33 @@
         "name": "next"
       }
     ],
-    "baseUrl": ".",
     "paths": {
       "~/*": [
-        "src/*"
+        "./src/*"
       ],
       "app/*": [
-        "src/app/*"
+        "./src/app/*"
       ],
       "components/*": [
-        "src/components/*"
+        "./src/components/*"
       ],
       "data/*": [
-        "src/data/*"
+        "./src/data/*"
       ],
       "styles/*": [
-        "src/styles/*"
+        "./src/styles/*"
       ],
       "hooks/*": [
-        "src/hooks/*"
+        "./src/hooks/*"
       ],
       "public/*": [
-        "public/*"
+        "./public/*"
       ],
       "types/*": [
-        "src/types/*"
+        "./src/types/*"
       ],
       "lib/*": [
-        "src/lib/*"
+        "./src/lib/*"
       ]
     }
   },


### PR DESCRIPTION
# Description

Fixes #199.

Remove the deprecated TypeScript `baseUrl` setting while preserving the
existing path alias behavior.

Without `baseUrl`, TypeScript requires path mapping targets to be explicitly
relative to `tsconfig.json`. Update all existing `paths` targets from forms
such as `src/*` to `./src/*`.

This keeps the current resolution behavior unchanged while making the
configuration compatible with TypeScript versions where `baseUrl` is
deprecated or removed.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Validation

Current project toolchain:

- `npm ci` — passed
- `npx tsc --noEmit` — passed with TypeScript 5.9.3
- `npm run build` — passed
- `npm run lint` — passed

Forward-compatibility validation:

- TypeScript 6.0.0-beta: `tsc --noEmit -p tsconfig.json` — passed
- TypeScript 7.0.2: `tsc --noEmit -p tsconfig.json` — passed

No dependency or lockfile changes are included.

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented in this PR
- [x] All code style checks pass
- [x] The affected configuration is covered by TypeScript, build, and lint validation
- [x] All new and existing applicable checks pass
